### PR TITLE
Unify log file names for regression tests

### DIFF
--- a/ci/jobs-dev/run_post_3drtma_HERA.sh
+++ b/ci/jobs-dev/run_post_3drtma_HERA.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#SBATCH -o out.post.rtma
-#SBATCH -e out.post.rtma
+#SBATCH -o out.post.3drtma
+#SBATCH -e out.post.3drtma
 #SBATCH -J rtma_test
 #SBATCH -t 00:20:00
 ##SBATCH -q debug

--- a/ci/jobs-dev/run_post_3drtma_HERCULES.sh
+++ b/ci/jobs-dev/run_post_3drtma_HERCULES.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#SBATCH -o out.post.rtma
-#SBATCH -e out.post.rtma
+#SBATCH -o out.post.3drtma
+#SBATCH -e out.post.3drtma
 #SBATCH -J rtma_test
 #SBATCH -t 00:30:00
 #SBATCH -N 5 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_3drtma_ORION.sh
+++ b/ci/jobs-dev/run_post_3drtma_ORION.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#SBATCH -o out.post.rtma
-#SBATCH -e out.post.rtma
+#SBATCH -o out.post.3drtma
+#SBATCH -e out.post.3drtma
 #SBATCH -J rtma_test
 #SBATCH -t 00:30:00
 #SBATCH -N 8 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_3drtma_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_3drtma_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#PBS -o out.3drtma
-#PBS -e out.3drtma
+#PBS -o out.post.3drtma
+#PBS -e out.post.3drtma
 #PBS -N 3drtma.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_fv3gefs_HERA.sh
+++ b/ci/jobs-dev/run_post_fv3gefs_HERA.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3gefs
-#SBATCH -e out.fv3gefs
+#SBATCH -o out.post.fv3gefs
+#SBATCH -e out.post.fv3gefs
 #SBATCH -J fv3gefs_test 
 #SBATCH -t 00:30:00
 #SBATCH -N 3 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3gefs_HERCULES.sh
+++ b/ci/jobs-dev/run_post_fv3gefs_HERCULES.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3gefs
-#SBATCH -e out.fv3gefs
+#SBATCH -o out.post.fv3gefs
+#SBATCH -e out.post.fv3gefs
 #SBATCH -J fv3gefs_test 
 #SBATCH -t 00:30:00
 #SBATCH -N 3 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3gefs_ORION.sh
+++ b/ci/jobs-dev/run_post_fv3gefs_ORION.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3gefs
-#SBATCH -e out.fv3gefs
+#SBATCH -o out.post.fv3gefs
+#SBATCH -e out.post.fv3gefs
 #SBATCH -J fv3gefs_test 
 #SBATCH -t 00:30:00
 #SBATCH -N 3 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3gefs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_fv3gefs_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#PBS -o out.fv3gefs
-#PBS -e out.fv3gefs
+#PBS -o out.post.fv3gefs
+#PBS -e out.post.fv3gefs
 #PBS -N fv3gefs.test
 #PBS -l walltime=00:10:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_fv3gfs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_fv3gfs_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o out.fv3gfs
-#PBS -e out.fv3gfs
+#PBS -o out.post.fv3gfs
+#PBS -e out.post.fv3gfs
 #PBS -N fv3gfs.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_fv3hafs_HERA.sh
+++ b/ci/jobs-dev/run_post_fv3hafs_HERA.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3hafs
-#SBATCH -e out.fv3hafs
+#SBATCH -o out.post.fv3hafs
+#SBATCH -e out.post.fv3hafs
 #SBATCH -J fv3hafs_test 
 #SBATCH -t 00:20:00
 #SBATCH -N 5 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3hafs_HERCULES.sh
+++ b/ci/jobs-dev/run_post_fv3hafs_HERCULES.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3hafs
-#SBATCH -e out.fv3hafs
+#SBATCH -o out.post.fv3hafs
+#SBATCH -e out.post.fv3hafs
 #SBATCH -J fv3hafs_test 
 #SBATCH -t 00:20:00
 #SBATCH -N 5 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3hafs_ORION.sh
+++ b/ci/jobs-dev/run_post_fv3hafs_ORION.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.fv3hafs
-#SBATCH -e out.fv3hafs
+#SBATCH -o out.post.fv3hafs
+#SBATCH -e out.post.fv3hafs
 #SBATCH -J fv3hafs_test 
 #SBATCH -t 00:20:00
 #SBATCH -N 5 --ntasks-per-node=12

--- a/ci/jobs-dev/run_post_fv3hafs_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_fv3hafs_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o out.hafs
-#PBS -e out.hafs
+#PBS -o out.post.fv3hafs
+#PBS -e out.post.fv3hafs
 #PBS -N hafs.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_fv3r_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_fv3r_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o out.fv3r
-#PBS -e out.fv3r
+#PBS -o out.post.fv3r
+#PBS -e out.post.fv3r
 #PBS -N fv3r.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_fv3r_ifi_missing_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_fv3r_ifi_missing_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o out.fv3r_ifi_missing
-#PBS -e out.fv3r_ifi_missing
+#PBS -o out.post.fv3r_ifi_missing
+#PBS -e out.post.fv3r_ifi_missing
 #PBS -N fv3r_ifi_missing
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_hrrr_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_hrrr_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#PBS -o out.hrrr
-#PBS -e out.hrrr
+#PBS -o out.post.hrrr
+#PBS -e out.post.hrrr
 #PBS -N hrrr.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_nmmb_HERA.sh
+++ b/ci/jobs-dev/run_post_nmmb_HERA.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.post.nmmb_Grib2
-#SBATCH -e out.post.nmmb_Grib2
+#SBATCH -o out.post.nmmb
+#SBATCH -e out.post.nmmb
 #SBATCH -J nmmb_test
 #SBATCH -t 00:20:00
 ##SBATCH -q debug

--- a/ci/jobs-dev/run_post_nmmb_HERCULES.sh
+++ b/ci/jobs-dev/run_post_nmmb_HERCULES.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.post.nmmb_Grib2
-#SBATCH -e out.post.nmmb_Grib2
+#SBATCH -o out.post.nmmb
+#SBATCH -e out.post.nmmb
 #SBATCH -J nmmb_test
 #SBATCH -t 00:20:00
 #SBATCH -q debug
@@ -22,6 +22,7 @@ date
 ############################################
 # Loading module
 ############################################
+
 module use /apps/contrib/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.9.0/install/modulefiles/Core
 module load stack-intel/2021.9.0
 module load stack-intel-oneapi-mpi/2021.9.0

--- a/ci/jobs-dev/run_post_nmmb_ORION.sh
+++ b/ci/jobs-dev/run_post_nmmb_ORION.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#SBATCH -o out.post.nmmb_Grib2
-#SBATCH -e out.post.nmmb_Grib2
+#SBATCH -o out.post.nmmb
+#SBATCH -e out.post.nmmb
 #SBATCH -J nmmb_test
 #SBATCH -t 00:20:00
 #SBATCH -q debug
@@ -22,7 +22,6 @@ date
 ############################################
 # Loading module
 ############################################
-
 module use /apps/contrib/spack-stack/spack-stack-1.8.0/envs/ue-intel-2021.9.0/install/modulefiles/Core
 module load stack-intel/2021.9.0
 module load stack-intel-oneapi-mpi/2021.9.0

--- a/ci/jobs-dev/run_post_nmmb_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_nmmb_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o out.nmmb.test
-#PBS -e out.nmmb.test
+#PBS -o out.post.nmmb
+#PBS -e out.post.nmmb
 #PBS -N nmmb.test
 #PBS -l walltime=00:30:00
 #PBS -q debug

--- a/ci/jobs-dev/run_post_rap_WCOSS2.sh
+++ b/ci/jobs-dev/run_post_rap_WCOSS2.sh
@@ -1,7 +1,7 @@
 #!/bin/sh 
  
-#PBS -o out.rap
-#PBS -e out.rap
+#PBS -o out.post.rap
+#PBS -e out.post.rap
 #PBS -N rap.test
 #PBS -l walltime=00:30:00
 #PBS -q debug


### PR DESCRIPTION
For the UPP regression tests, the names of the log files are unified to have the "out.post" prefix.  In addition, run_post_nmmb_Grib2_HERCULES.sh and run_post_nmmb_Grib2_ORION.sh are renamed to run_post_nmmb_HERCULES.sh and run_post_nmmb_ORION.sh to match the names used for the Hera and WCOSS2 nmmb tests.  If it would be preferable to leave the nmmb script names the same, I can change those back.